### PR TITLE
fix(test): update unstable TestFormatDateHelper

### DIFF
--- a/internal/adapter/handlebars/handlebars_test.go
+++ b/internal/adapter/handlebars/handlebars_test.go
@@ -238,7 +238,13 @@ func TestFormatDateHelper(t *testing.T) {
 	testString(t, "{{format-date now 'timestamp'}}", context, "200911172034")
 	testString(t, "{{format-date now 'timestamp-unix'}}", context, "1258490098")
 	testString(t, "{{format-date now 'cust: %Y-%m'}}", context, "cust: 2009-11")
-	testString(t, "{{format-date now 'elapsed'}}", context, "14 years ago")
+}
+
+// This test is not stable and needs to be updated once a year on Nov 21 UTC
+func TestFormatDateHelperElapsed(t *testing.T) {
+	context := map[string]interface{}{"now": time.Date(2009, 11, 21, 0, 0, 0, 0, time.UTC)}
+
+	testString(t, "{{format-date now 'elapsed'}}", context, "15 years ago")
 }
 
 func TestDateHelper(t *testing.T) {


### PR DESCRIPTION
This test depends on the time when the test is executed. There appears that there is no way of mocking the time used in the 'elapsed' template function, and thus the test needs to be updated once a year.

The specific test case now runs in a separate test and it includes a comment explaining why it will start failing after a year has passed.